### PR TITLE
Add responsiveness for smaller screen on events page

### DIFF
--- a/src/pages/Events/Events.tsx
+++ b/src/pages/Events/Events.tsx
@@ -42,7 +42,7 @@ const Events = () => {
           {upcomingEventLogos.map((logo, index) => (
             <div
               key={index}
-              className="col-6 col-sm-6 col-lg-3 d-flex justify-content-center align-items-center mb-4"
+              className="col-10 col-sm-12 col-md-6 col-lg-3 d-flex justify-content-center align-items-center mb-4"
             >
               <div className="container event-logo-container">
                 <img
@@ -66,7 +66,7 @@ const Events = () => {
           {pastEventLogos.map((logo, index) => (
             <div
               key={index}
-              className="col-6 col-sm-6 col-lg-3 d-flex justify-content-center align-items-center mb-4"
+              className="col-10 col-sm-12 col-md-6 col-lg-3 d-flex justify-content-center align-items-center mb-4"
             >
               <div className="container event-logo-container">
                 <img

--- a/src/pages/Events/events.css
+++ b/src/pages/Events/events.css
@@ -26,3 +26,47 @@
     height: 350px;
     width: 250px;
 }
+
+@media (max-width: 990px) {
+    body {
+        width: max-content;
+    }
+    .event-logo-container{
+        height: 100%;
+        width: 100%;
+        padding: 0;
+        margin: 0;
+    }
+    .event-logo{
+        height: 100%;
+        width: 100%;
+    }
+}
+
+
+@media (max-width: 576px) {
+    body {
+        width: fit-content;
+    }
+
+    .event-logo-container{
+        height: 90%;
+        width: 60%;
+        padding: 0;
+        margin: 0;
+    }
+    .event-logo{
+        height: 100%;
+        width: 80%;
+    }
+    
+    .header-image{
+        width: 50%;
+        height: 50vh;
+        object-fit: cover;
+    }
+
+    .container.mt-4{
+        margin-left: 10%;
+    }
+}


### PR DESCRIPTION
Change the events logo to display one event at a time for smaller screen for different breakpoints.
Fix empty white space css style.
Changes in both `Events.tsx` and `events.css`

Closes #32 