### PR TITLE
Fix: shrink council member card when only 1 card and links to images in footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,8 @@
-import instagramIcon from "../../public/social-icons/Instagram.png"
-import discordIcon from "../../public/social-icons/Discord.png"
-import mailIcon from "../../public/social-icons/mail.png"
-import linkedInIcon from "../../public/social-icons/LinkedIn.png"
-import twitterIcon from "../../public/social-icons/Twitter.png"
+import instagramIcon from "/social-icons/Instagram.png";
+import discordIcon from "/social-icons/Discord.png";
+import mailIcon from "/social-icons/mail.png";
+import linkedInIcon from "/social-icons/LinkedIn.png";
+import twitterIcon from "/public/social-icons/Twitter.png";
 const Footer = () => {
   const contactIcons = (
     <div className="flex m-0 p-0 h-[39px] items-center gap-[25px]">
@@ -10,50 +10,35 @@ const Footer = () => {
         href="mailto:contact@tesc.ucsd.edu"
         className="text-white text-[clamp(20px,2vw,26px)] leading-[39px]"
       >
-        <img
-          src={mailIcon}
-          alt="Mail"
-        />
+        <img src={mailIcon} alt="Mail" />
       </a>
 
       <a
         href="https://www.instagram.com/tesc.at.ucsd"
         className=" text-white text-[clamp(20px,2vw,26px)] leading-[39px]"
       >
-        <img
-          src={instagramIcon}
-          alt="Instagram"
-        />
+        <img src={instagramIcon} alt="Instagram" />
       </a>
 
       <a
         href="https://www.linkedin.com/company/ucsdtesc"
         className=" text-white text-[clamp(20px,2vw,26px)] leading-[39px]"
       >
-        <img
-          src={linkedInIcon}
-          alt="LinkedIn"
-          />
+        <img src={linkedInIcon} alt="LinkedIn" />
       </a>
 
       <a
         href="https://x.com/UCSDTESC/"
         className=" text-white text-[clamp(20px,2vw,26px)] leading-[39px]"
       >
-        <img
-          src={twitterIcon}
-          alt="Twitter"
-        />
+        <img src={twitterIcon} alt="Twitter" />
       </a>
 
       <a
         href="https://tescucsd.org/discord"
         className=" text-white text-[clamp(20px,2vw,26px)] leading-[39px]"
       >
-        <img
-          src={discordIcon}
-          alt="Discord"
-        />
+        <img src={discordIcon} alt="Discord" />
       </a>
     </div>
   );
@@ -62,11 +47,10 @@ const Footer = () => {
     <>
       <footer className="bg-radial from-[#114675] from-40% to-navy w-full py-12 px-18 sm:px-25 md:px-34 lg:px-40 xl:px-55">
         <div className="max-w-5xl flex flex-col items-start text-left">
-          <h2 className="text-offWhite text-[26px] font-bold mb-3">
-        Interested? Connect with us!
-          </h2>
+          <h2 className="text-offWhite text-[26px] font-bold mb-3">Interested? Connect with us!</h2>
           <p className="text-offWhite text-[16px] font-normal max-w-md leading-relaxed mb-5">
-        Stay connected with us! Follow us for updates on events, opportunities, and ways to get involved.
+            Stay connected with us! Follow us for updates on events, opportunities, and ways to get
+            involved.
           </p>
           {contactIcons}
         </div>

--- a/src/pages/CouncilMembersPage/CouncilMembers.tsx
+++ b/src/pages/CouncilMembersPage/CouncilMembers.tsx
@@ -1,4 +1,4 @@
-import {  useState } from "react";
+import { useState } from "react";
 import CouncilMemberGrid from "./CouncilMemberGrid";
 import {
   allCouncilMembers,
@@ -10,7 +10,7 @@ import {
   mechanicalOrgs,
   roboticsOrgs,
   generalMiscOrgs,
-  CouncilMember
+  CouncilMember,
 } from "./council-member-data";
 import useImagePreloader from "../../Hooks/useImagePreload";
 
@@ -23,7 +23,7 @@ const categories: string[] = [
   "Electrical",
   "Mechanical",
   "Robotics",
-  "General/Misc"
+  "General/Misc",
 ];
 
 const categoryMap: { [key: string]: CouncilMember[] } = {
@@ -35,14 +35,12 @@ const categoryMap: { [key: string]: CouncilMember[] } = {
   Electrical: electricalOrgs,
   Mechanical: mechanicalOrgs,
   Robotics: roboticsOrgs,
-  "General/Misc": generalMiscOrgs
+  "General/Misc": generalMiscOrgs,
 };
 
 const CouncilMembers = () => {
   const [category, setCategory] = useState<string>("All");
-  const imagePreloader = useImagePreloader([
-    "AllPages/council-page-image.webp",
-  ]);
+  const imagePreloader = useImagePreloader(["AllPages/council-page-image.webp"]);
   return (
     <div className="min-h-fit max-w-[90%] m-auto">
       <div className="mt-20 mb-20 flex-col flex justify-center items-center">
@@ -80,27 +78,27 @@ const CouncilMembers = () => {
             </select>
           </div>
           <div className="hidden md:flex flex-wrap justify-center items-center font-bold w-full max-w-[90%] mx-auto p-2 bg-white border-[#0000001A] border rounded-full shadow-xl gap-x-4 gap-y-1">
-          {categories.map((type, index) => {
-            return (
-              <p
-                key={index}
-                className={`hover:cursor-pointer ${
-                  category == type && "p-1 px-3 rounded-full bg-[#0000001A]"
-                } ${index == 0 && "ml-4"} ${
-                  index == categories.length - 1 && "mr-16"
-                } transition-all duration-600 ease-in-out transform`}
-                onClick={() => setCategory(type)}
-              >
-                {type}
-              </p>
-            );
-          })}
+            {categories.map((type, index) => {
+              return (
+                <p
+                  key={index}
+                  className={`hover:cursor-pointer ${
+                    category == type && "p-1 px-3 rounded-full bg-[#0000001A]"
+                  } ${index == 0 && "ml-4"} ${
+                    index == categories.length - 1 && "mr-16"
+                  } transition-all duration-600 ease-in-out transform`}
+                  onClick={() => setCategory(type)}
+                >
+                  {type}
+                </p>
+              );
+            })}
           </div>
         </div>
         <p className="font-semibold text-[30px] text-[#11426B] leading-14 mb-3 mt-10">
           {category} Council Members
         </p>
-        <div className="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] justify-center items-center my-4 mx-auto w-[80%] gap-10">
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] justify-center items-center my-4 mx-auto w-[80%] gap-10">
           <CouncilMemberGrid data={categoryMap[category]} />
         </div>
       </div>


### PR DESCRIPTION
Shrunk council member cards so that it displays small even when only 1 card is available. 
changed links for images in footer